### PR TITLE
Add service worker for offline caching and faster loading

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,3 +83,9 @@ document.addEventListener('DOMContentLoaded', function (event) {
     }
   }
 })
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,42 @@
+var CACHE = 'cache-and-update';
+
+self.addEventListener('install', function (evt) {
+  console.log('The service worker is being installed.');
+
+  evt.waitUntil(precache());
+});
+
+self.addEventListener('fetch', function (evt) {
+  console.log('The service worker is serving the asset.');
+  evt.respondWith(fromCache(evt.request));
+  evt.waitUntil(update(evt.request));
+});
+
+function precache() {
+  return caches.open(CACHE).then(function (cache) {
+    return cache.addAll([
+      './index.html',
+      './index.js',
+      './main.css',
+      'img/morning.png',
+      'img/day.png',
+      'img/night.png',
+    ]);
+  });
+}
+
+function fromCache(request) {
+  return caches.open(CACHE).then(function (cache) {
+    return cache.match(request).then(function (matching) {
+      return matching || Promise.reject('no-match');
+    });
+  });
+}
+
+function update(request) {
+  return caches.open(CACHE).then(function (cache) {
+    return fetch(request).then(function (response) {
+      return cache.put(request, response);
+    });
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,6 +3,7 @@ var CACHE = 'cache-and-update';
 self.addEventListener('install', function (evt) {
   console.log('The service worker is being installed.');
 
+  self.skipWaiting();
   evt.waitUntil(precache());
 });
 


### PR DESCRIPTION
I have added a basic service worker. It precaches all static resources and then uses the cache-while-revalidate strategy to serve them. This means everything will be served from the cache first, and then the cache will be updated with the latest response in the background.

The downside is that after any change, you will need two refreshes to get the updated content. The upside is that the page will load instantly, regardless of network speed.