### PR TITLE
Remove leading slash while registering service worker

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,6 @@ document.addEventListener('DOMContentLoaded', function (event) {
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/service-worker.js');
+    navigator.serviceWorker.register('service-worker.js');
   });
 }


### PR DESCRIPTION
I merged your upstream into my fork and it couldn't fetch the service worker at all. Threw a 404, because it was looking for it in `dar5hak.github.io/service-worker.js` instead of `dar5hak.github.io/start/service-worker.js`.

Classic slip-up that doesn't appear till you deploy it. :sweat_smile: 